### PR TITLE
fix Fatal Exception: android.view.WindowManager

### DIFF
--- a/GsAdmob/src/main/java/com/core/gsadmob/adapter/BaseWithAdsAdapter.kt
+++ b/GsAdmob/src/main/java/com/core/gsadmob/adapter/BaseWithAdsAdapter.kt
@@ -19,7 +19,7 @@ abstract class BaseWithAdsAdapter(context: Context) : RecyclerView.Adapter<Recyc
     /**
      * Dùng cho trường hợp dữ liệu lấy được quá chậm sau khi khởi tải được quảng cáo rồi
      */
-    var isStartShimmer: Boolean = false
+    private var isStartShimmer: Boolean = false
 
     /**
      * Layout id native quảng cáo
@@ -152,13 +152,13 @@ abstract class BaseWithAdsAdapter(context: Context) : RecyclerView.Adapter<Recyc
      * Phần xử lý quảng cáo native
      */
     inner class NativeAdHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val nativeGsAdView: NativeGsAdView? = itemView.findViewById(nativeAdId)
+        private val nativeGsAdView: NativeGsAdView? = itemView.findViewById(nativeAdId)
 
         fun bind(itemAds: ItemAds) {
             nativeGsAdView?.let {
                 it.setNativeAd(nativeAd = itemAds.nativeAd, isStartShimmer = itemAds.isLoading)
 
-                itemAds.nativeAd?.let { nativeAd ->
+                itemAds.nativeAd?.let { _ ->
                     if (canCheckUpdateCallActionButton) {
                         it.updateCallActionButton(getBackgroundResourceCallActionButton(adapterPosition))
                     }


### PR DESCRIPTION
          Fatal Exception: android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@1a9a45f is not valid; is your activity running?
       at android.view.ViewRootImpl.setView(ViewRootImpl.java:1588)
       at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:509)
       at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:133)
       at android.app.Dialog.show(Dialog.java:512)
       at com.core.gsadmob.utils.AdGsRewardedManager.checkShowRewardedAds$lambda$6(AdGsRewardedManager.kt:119)
       at com.core.gscore.utils.network.NetworkUtils$hasInternetAccessCheck$1$1.invokeSuspend(NetworkUtils.kt:143)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8669)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
        