### PR TITLE
Thêm hàm gọi 2 quảng cáo xen kẽ mặc định

### DIFF
--- a/GsAdmob/src/main/java/com/core/gsadmob/callback/AdGsExtendListener.kt
+++ b/GsAdmob/src/main/java/com/core/gsadmob/callback/AdGsExtendListener.kt
@@ -1,9 +1,21 @@
 package com.core.gsadmob.callback
 
+import com.google.android.gms.ads.AdValue
+
 interface AdGsExtendListener {
 
     /**
      * Khi người dùng ấn vào quảng cáo
      */
     fun onAdClicked() {}
+
+    /**
+     * Xác nhận quảng cáo thực sự xuất hiện trên giao diện (đủ điều kiện visibility theo tiêu chuẩn IAB)
+     */
+    fun onAdImpression() {}
+
+    /**
+     * Theo dõi doanh thu: Ghi lại giá trị mỗi khi quảng cáo hiển thị thành công và người dùng tương tác
+     */
+    fun onPaidEvent(adValue: AdValue) {}
 }

--- a/GsAdmob/src/main/java/com/core/gsadmob/model/base/BaseAdGsData.kt
+++ b/GsAdmob/src/main/java/com/core/gsadmob/model/base/BaseAdGsData.kt
@@ -8,7 +8,6 @@ open class BaseAdGsData(
     var extendListener: AdGsExtendListener? = null,
     var isReload: Boolean = false,
     var isLoading: Boolean = false,
-    var isUsed: Boolean = false,
     var delayTime: Long = 0L,
     var lastTime: Long = 0L,
     var delayShowTime: Long = 0L,

--- a/GsAdmob/src/main/java/com/core/gsadmob/utils/AdGsManager.kt
+++ b/GsAdmob/src/main/java/com/core/gsadmob/utils/AdGsManager.kt
@@ -102,7 +102,6 @@ class AdGsManager {
      * @param canShowAppOpenResume điều kiện để có thể hiển thị quảng cáo app open resume
      * @param requireScreenAdLoading = true cần màn hình chờ tải quảng cáo app open resume
      * @param callbackNothingLifecycle thường dùng để thiết lập 1 số logic khác (ví dụ retry vip hoặc Lingver)
-     * @param callbackChangeVip trả về activity hiện tại và trạng thái vip hiện tại (mục đích là để cập nhật giao diện cho ứng dụng)
      * @param whitePackageNameList danh sách các packageName được dùng trong ứng dụng (kiểu là applicationId khác packageName của app)
      * @param showLog có muốn hiển thị log không?
      */
@@ -115,7 +114,6 @@ class AdGsManager {
         canShowAppOpenResume: (currentActivity: AppCompatActivity) -> Boolean = { false },
         requireScreenAdLoading: Boolean = true,
         callbackNothingLifecycle: (() -> Unit)? = null,
-        callbackChangeVip: ((currentActivity: Activity?, isVip: Boolean) -> Unit)? = null,
         whitePackageNameList: MutableList<String> = mutableListOf<String>(applicationId),
         showLog: Boolean = false
     ) {
@@ -242,7 +240,6 @@ class AdGsManager {
                     .stateIn(this, SharingStarted.Eagerly, VipPreferences.instance.isFullVersion())
                     .collect { isVip ->
                         notifyVip(isVip)
-                        callbackChangeVip?.invoke(currentActivity, isVip)
                     }
             }
 
@@ -402,8 +399,8 @@ class AdGsManager {
                         showAd(adPlaceName = adPlaceName, requiredLoadNewAds = requiredLoadNewAds, onlyShow = true)
                     }
 
-                    adGsData.appOpenAd?.onPaidEventListener = OnPaidEventListener {
-                        adGsData.isUsed = true
+                    adGsData.appOpenAd?.onPaidEventListener = OnPaidEventListener { adValue ->
+                        adGsData.extendListener?.onPaidEvent(adValue)
                     }
 
                     adGsData.appOpenAd?.fullScreenContentCallback = object : FullScreenContentCallback() {
@@ -434,6 +431,10 @@ class AdGsManager {
 
                         override fun onAdClicked() {
                             adGsData.extendListener?.onAdClicked()
+                        }
+
+                        override fun onAdImpression() {
+                            adGsData.extendListener?.onAdImpression()
                         }
                     }
                 }
@@ -466,8 +467,8 @@ class AdGsManager {
 
         bannerAdView.loadAd(adRequest)
 
-        bannerAdView.onPaidEventListener = OnPaidEventListener {
-            adGsData.isUsed = true
+        bannerAdView.onPaidEventListener = OnPaidEventListener { adValue ->
+            adGsData.extendListener?.onPaidEvent(adValue)
         }
 
         bannerAdView.adListener = object : AdListener() {
@@ -496,6 +497,10 @@ class AdGsManager {
 
             override fun onAdClicked() {
                 adGsData.extendListener?.onAdClicked()
+            }
+
+            override fun onAdImpression() {
+                adGsData.extendListener?.onAdImpression()
             }
         }
     }
@@ -554,8 +559,8 @@ class AdGsManager {
                         showAd(adPlaceName = adPlaceName, requiredLoadNewAds = requiredLoadNewAds, onlyShow = true)
                     }
 
-                    adGsData.interstitialAd?.onPaidEventListener = OnPaidEventListener {
-                        adGsData.isUsed = true
+                    adGsData.interstitialAd?.onPaidEventListener = OnPaidEventListener { adValue ->
+                        adGsData.extendListener?.onPaidEvent(adValue)
                     }
 
                     adGsData.interstitialAd?.fullScreenContentCallback = object : FullScreenContentCallback() {
@@ -587,6 +592,10 @@ class AdGsManager {
                         override fun onAdClicked() {
                             adGsData.extendListener?.onAdClicked()
                         }
+
+                        override fun onAdImpression() {
+                            adGsData.extendListener?.onAdImpression()
+                        }
                     }
                 }
             }
@@ -613,6 +622,10 @@ class AdGsManager {
                 override fun onAdClicked() {
                     adGsData.extendListener?.onAdClicked()
                 }
+
+                override fun onAdImpression() {
+                    adGsData.extendListener?.onAdImpression()
+                }
             }).forNativeAd { nativeAd ->
                 shimmerMap[adPlaceName] = false
                 adGsData.lastTime = System.currentTimeMillis()
@@ -623,8 +636,8 @@ class AdGsManager {
                     adGsData.nativeAd = nativeAd
                     adGsData.isLoading = false
 
-                    adGsData.nativeAd?.setOnPaidEventListener {
-                        adGsData.isUsed = true
+                    adGsData.nativeAd?.setOnPaidEventListener { adValue ->
+                        adGsData.extendListener?.onPaidEvent(adValue)
                     }
 
                     notifyAds("loadNativeAd.forNativeAd")
@@ -663,8 +676,8 @@ class AdGsManager {
                         showAd(adPlaceName = adPlaceName, requiredLoadNewAds = requiredLoadNewAds, onlyShow = true)
                     }
 
-                    adGsData.rewardedAd?.onPaidEventListener = OnPaidEventListener {
-                        adGsData.isUsed = true
+                    adGsData.rewardedAd?.onPaidEventListener = OnPaidEventListener { adValue ->
+                        adGsData.extendListener?.onPaidEvent(adValue)
                     }
 
                     adGsData.rewardedAd?.fullScreenContentCallback = object : FullScreenContentCallback() {
@@ -694,6 +707,10 @@ class AdGsManager {
 
                         override fun onAdClicked() {
                             adGsData.extendListener?.onAdClicked()
+                        }
+
+                        override fun onAdImpression() {
+                            adGsData.extendListener?.onAdImpression()
                         }
                     }
                 }
@@ -733,8 +750,8 @@ class AdGsManager {
                         showAd(adPlaceName = adPlaceName, requiredLoadNewAds = requiredLoadNewAds, onlyShow = true)
                     }
 
-                    adGsData.rewardedInterstitialAd?.onPaidEventListener = OnPaidEventListener {
-                        adGsData.isUsed = true
+                    adGsData.rewardedInterstitialAd?.onPaidEventListener = OnPaidEventListener { adValue ->
+                        adGsData.extendListener?.onPaidEvent(adValue)
                     }
 
                     adGsData.rewardedInterstitialAd?.fullScreenContentCallback = object : FullScreenContentCallback() {
@@ -764,6 +781,10 @@ class AdGsManager {
 
                         override fun onAdClicked() {
                             adGsData.extendListener?.onAdClicked()
+                        }
+
+                        override fun onAdImpression() {
+                            adGsData.extendListener?.onAdImpression()
                         }
                     }
                 }
@@ -1159,6 +1180,46 @@ class AdGsManager {
                 callbackFailed?.invoke()
             }
         }
+    }
+
+    /**
+     * Cách gọi hiển thị nhanh quảng cáo Interstitial mặc định AD_PLACE_NAME_INTERSTITIAL
+     */
+    fun showInterstitial(
+        requiredLoadNewAds: Boolean = false,
+        onlyShow: Boolean = false,
+        onlyCheckNotShow: Boolean = false,
+        callbackShow: ((adShowStatus: AdShowStatus) -> Unit)? = null,
+        adGsExtendListener: AdGsExtendListener? = null
+    ) {
+        instance.showAd(
+            adPlaceName = AdPlaceNameDefaultConfig.instance.AD_PLACE_NAME_INTERSTITIAL,
+            requiredLoadNewAds = requiredLoadNewAds,
+            onlyShow = onlyShow,
+            onlyCheckNotShow = onlyCheckNotShow,
+            callbackShow = callbackShow,
+            adGsExtendListener = adGsExtendListener
+        )
+    }
+
+    /**
+     * Cách gọi hiển thị nhanh quảng cáo Interstitial mặc định AD_PLACE_NAME_INTERSTITIAL_WITHOUT_VIDEO
+     */
+    fun showInterstitialWithoutVideo(
+        requiredLoadNewAds: Boolean = false,
+        onlyShow: Boolean = false,
+        onlyCheckNotShow: Boolean = false,
+        callbackShow: ((adShowStatus: AdShowStatus) -> Unit)? = null,
+        adGsExtendListener: AdGsExtendListener? = null
+    ) {
+        instance.showAd(
+            adPlaceName = AdPlaceNameDefaultConfig.instance.AD_PLACE_NAME_INTERSTITIAL_WITHOUT_VIDEO,
+            requiredLoadNewAds = requiredLoadNewAds,
+            onlyShow = onlyShow,
+            onlyCheckNotShow = onlyCheckNotShow,
+            callbackShow = callbackShow,
+            adGsExtendListener = adGsExtendListener
+        )
     }
 
     /**

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,14 @@
+**Version 1.4.8**
+
+- Xóa `callbackChangeVip` ở `AdGsManager.registerCoroutineScope()`
+- Thêm 2 function gọi hiển thị nhanh 2 quảng cáo Interstitial mặc định `showInterstitial`, `showInterstitialWithoutVideo`
+
+  ```css
+        AdGsManager.instance.showInterstitial()
+
+        AdGsManager.instance.showInterstitialWithoutVideo()
+  ```    
+
 **Version 1.4.7**
 - Sửa chức năng callbackChangeVip từ giờ sẽ chỉ trả về currentActivity của ứng dụng
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,14 @@ Hướng dẫn chi tiết cách dùng xem ở [SplashActivity](https://github.co
   ```
 
 ### Quảng cáo Interstitial
+- Hiển thị 2 quảng cáo xen kẽ mặc định
 
+  ```css
+        AdGsManager.instance.showInterstitial()
+
+        AdGsManager.instance.showInterstitialWithoutVideo()
+  ```
+  
 - Hiển thị quảng cáo xen kẽ
 
   ```css

--- a/app/src/main/java/com/example/gsadmob/ui/activity/TestAdsActivity.kt
+++ b/app/src/main/java/com/example/gsadmob/ui/activity/TestAdsActivity.kt
@@ -50,9 +50,14 @@ class TestAdsActivity : BaseAdsActivity<ActivityTestAdsBinding>(ActivityTestAdsB
 
         bindingView.tvInterstitial.setOnClickListener {
             startActivity(Intent(this, TestNativeActivity::class.java))
-            AdGsManager.instance.showAd(
-                adPlaceName = AdPlaceNameDefaultConfig.instance.AD_PLACE_NAME_INTERSTITIAL,
-                adGsExtendListener = object : AdGsExtendListener {
+//            AdGsManager.instance.showAd(
+//                adPlaceName = AdPlaceNameDefaultConfig.instance.AD_PLACE_NAME_INTERSTITIAL,
+//                adGsExtendListener = object : AdGsExtendListener {
+//                override fun onAdClicked() {
+//                    Log.d("TAG5", "TestAdsActivity_onAdClicked: AD_PLACE_NAME_INTERSTITIAL")
+//                }
+//            })
+            AdGsManager.instance.showInterstitial(adGsExtendListener = object : AdGsExtendListener {
                 override fun onAdClicked() {
                     Log.d("TAG5", "TestAdsActivity_onAdClicked: AD_PLACE_NAME_INTERSTITIAL")
                 }
@@ -61,7 +66,12 @@ class TestAdsActivity : BaseAdsActivity<ActivityTestAdsBinding>(ActivityTestAdsB
 
         bindingView.tvInterstitialWithoutVideo.setOnClickListener {
             startActivity(Intent(this, TestNativeActivity::class.java))
-            AdGsManager.instance.showAd(adPlaceName = AdPlaceNameDefaultConfig.instance.AD_PLACE_NAME_INTERSTITIAL_WITHOUT_VIDEO, adGsExtendListener = object : AdGsExtendListener {
+//            AdGsManager.instance.showAd(adPlaceName = AdPlaceNameDefaultConfig.instance.AD_PLACE_NAME_INTERSTITIAL_WITHOUT_VIDEO, adGsExtendListener = object : AdGsExtendListener {
+//                override fun onAdClicked() {
+//                    Log.d("TAG5", "TestAdsActivity_onAdClicked: AD_PLACE_NAME_INTERSTITIAL_WITHOUT_VIDEO")
+//                }
+//            })
+            AdGsManager.instance.showInterstitialWithoutVideo(adGsExtendListener = object : AdGsExtendListener {
                 override fun onAdClicked() {
                     Log.d("TAG5", "TestAdsActivity_onAdClicked: AD_PLACE_NAME_INTERSTITIAL_WITHOUT_VIDEO")
                 }


### PR DESCRIPTION
- Thêm onAdImpression và onPaidEvent vào AdGsExtendListener 
- Bỏ tạm biến isUsed
- Xóa callbackChangeVip
- Thêm hàm gọi hiển thị quảng cáo xem kẽ mặc định showInterstitial và showInterstitialWithoutVideo